### PR TITLE
Add test of sphere example for ripsDiag()

### DIFF
--- a/tests/testthat/test_ripsDiag.R
+++ b/tests/testthat/test_ripsDiag.R
@@ -1,0 +1,19 @@
+testthat::context("ripsDiag")
+
+testthat::test_that("Test Rips diagram function with distance matrices", {
+  sphere_points <- matrix(c(-1, 0,	0, 1,	0, 0, 0, -1, 0,
+                             0, 1, 0, 0,	0, -1, 0,	0, 1),
+                          nrow = 6, ncol = 3)
+
+  # Use distance matrix for sphere
+  diag1 <- ripsDiag(dist(sphere_points), maxdimension = 2,
+                    maxscale = 5, dist = "arbitrary")
+
+  # Use distance  matrix
+  diag2 <- ripsDiag(sphere_points, maxdimension = 2,
+                    maxscale = 5, dist = "euclidean")
+
+  testthat::expect_equal(diag1$diagram[(diag2$diag[,'dimension'] == 2),2], sqrt(2))
+  testthat::expect_equal(diag2$diagram[(diag2$diag[,'dimension'] == 2),2], sqrt(2))
+})
+


### PR DESCRIPTION
This pull request is to give a test of a simple example of points on the unit sphere and the ripsDiag() function. There appears to currently be a bug in the code with respect to this example and using distance matrices to compute the persistence diagram.